### PR TITLE
Compatibility with pandas >= 2.0

### DIFF
--- a/MonoTools/tools.py
+++ b/MonoTools/tools.py
@@ -946,7 +946,7 @@ def update_lc_locs(epoch,most_recent_sect):
         resp, content = h.request(fitsloc)
         if int(resp['status']) < 400:
             filename=content.split(b'\n')[1].decode().split(' ')[-2].split('-')
-            epoch=epoch.append(pd.Series({'date':int(filename[0][4:]),'runid':int(filename[3])},name=sect))
+            epoch.loc[sect, ['date', 'runid']] = [int(filename[0][4:]), int(filename[3])]
         else:
             print("Sector "+str(sect)+" not (yet) found on MAST | RESPONCE:"+resp['status'])
     epoch.to_csv(MonoData_tablepath+"/tess_lc_locations.csv")


### PR DESCRIPTION
As of pandas v2.0.0, released 3 April 2023, the deprecated methods `Series.append()` and `DataFrame.append()` have been removed, (see [removal of prior version deprecations/changes](
https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes)).

As a result, the following line has been removed from `MonoTools/tools.py`
```python
epoch=epoch.append(pd.Series({'date':int(filename[0][4:]),'runid':int(filename[3])},name=sect))
```
and was replaced with
```python
epoch.loc[sect, ['date', 'runid']] = [int(filename[0][4:]), int(filename[3])]
```

Cheers!
David