### PR TITLE
fix: key error for tess-point module

### DIFF
--- a/MonoTools/lightcurve.py
+++ b/MonoTools/lightcurve.py
@@ -1128,7 +1128,7 @@ class multilc(lc):
                 sect_obs=tools.observed(int(id))
             #print({key:sect_obs[key] for key in epoch.index})
             #print(epoch.index,sect_obs.keys())
-            epochs=[key for key in epoch.index if sect_obs[key]]
+            epochs=[key for key in epoch.index if sect_obs.get(key, None)]
 
             if epochs==[]:
                 #NO EPOCHS OBSERVABLE APPARENTLY. USING THE EPOCHS ON EXOFOP/TIC8

--- a/MonoTools/tools.py
+++ b/MonoTools/tools.py
@@ -931,7 +931,7 @@ def observed(tic,radec=None,maxsect=96):
     #from tesspoint import tess_stars2px_function_entry as tess_stars2px
     result = tess_stars2px.tess_stars2px_function_entry(tic, radec.ra.deg, radec.dec.deg)
     sectors = result[3]
-    out_dic={s:True if s in sectors else False for s in np.arange(maxsect)}
+    out_dic={s:True if s in sectors else False for s in np.arange(1, maxsect + 1, 1)}
     #print(out_dic)
     return out_dic
 


### PR DESCRIPTION
Hi, I'm very excited to start using MonoTools to help plan upcoming observations!

I tried to follow the MonoTools tutorial (Example 1 - Modelling a Duotransit), but encountered some issues.

When running `lc=lightcurve.multilc(tic,'tess', save=False,load=False,use_fast=False)` and `mod=fit.monoModel(tic,'tess',lc=lc)` , it fails with `Keyerror: 96`. 

This happens because the check for the id in sect_obs assumes that the id already exists.  In tools.observed, the maximum sector is hardcoded to default to 96, but the indexing of out_dic starts at 0 (while TESS sector 0 does not exist). Therefore, key 96 was undefined. We fixed it by replacing the 0-index with 1-index and checking that the key exists.
Should the default maximum sector be updated?

The tutorial still includes `from MonoTools.MonoTools import fit,tools,starpars,lightcurve`, but starpars can no longer be imported. Is there a replacement for the usage in tutorial 1 (`mod.init_starpars()`)?

Thanks!